### PR TITLE
Command Arguments, Readme and few corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .idea/
+
+# Source Input and Skeletons Output
+src/
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,3 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .idea/
-
-# Source Input and Skeletons Output
-src/
-bin/

--- a/README.md
+++ b/README.md
@@ -19,12 +19,9 @@ You can now configure some parameters like the use of the snake case for
 method arguments in **CONSTANTS.py** (skeleton_maker folder).
 
 ## How to use :
+Execute the main script by doing `python main.py --help` to see the options
 
-* Put your src files with .cpp in **src** folder.
-* Launch **main.py** with `py main.py`.
-* Get output in **bin** folder.
-
-## Next Stape ?
+## Next Steps ?
 To continue, you can use [VegaS](https://github.com/Vegas007/)'s script to convert your python2 code to python3 : [Script here](https://github.com/Vegas007/Python-Code-Translator-2-to-3). 
 This will adapt your code to be usable both in python2 and python 3
 
@@ -39,6 +36,7 @@ This will adapt your code to be usable both in python2 and python 3
 * [Mali61](https://github.com/blackdragonx61) for having complete C++ functions list.
 * [Arves100](https://github.com/arves100) to have corrected something forgotten in the code.
 * msnas on [metin2dev](https://metin2.dev/profile/16588-msnas/) to have corrected the return type (NoReturn -> None)
+* [NewWars](https://github.com/OriDevTeam) for command arguments options
 
 ## License
 

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@
 
 # Imports:
 from skeleton_maker import *
+from argparse import ArgumentParser
 
 
 __author__ = "Takuma"
@@ -21,15 +22,32 @@ __credits__ = [
 	"msnas"  # Fixed return type (NoReturn -> None)
 ]
 
+from skeleton_maker import CONSTANTS
+
+
+def parse_args():
+	parser = ArgumentParser()
+	parser.add_argument('-s', '--source', required=True, type=str, help='Source location path')
+	parser.add_argument('-o', '--output', required=True, type=str, help='Output location path')
+	parser.add_argument('-f', '--format-snake-case', type=bool, default=True,
+	                    help='Formats the functions arguments to snake case style, example: '
+	                         'def func(p_arg: int) instead of def func(pArg:int)')
+	
+	return parser.parse_args()
+
 
 def main() -> None:
 	"""Main entry
 	Use this function to start the SkeletonMaker
 	"""
+	
+	args = parse_args()
+	CONSTANTS.FORMAT_ARGUMENTS_TO_SNAKE_CASE = args.format_snake_case
+	
 	print("Welcome !")
 	print("I was coded by Takuma! A Frenchman who loves baguettes!")
 	print("You can find me on my github: https://github.com/nicolasCDT/")
-	maker: SkeletonMaker = SkeletonMaker("src", "bin")
+	maker: SkeletonMaker = SkeletonMaker(args.source, args.output)
 	maker.process()
 
 	print("Have a nice day!")

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Hello, i thought instead of having to move the files to the project, command options could be given so avoiding having to move any files and just giving paths to make it easier, also including options like the snake case formatting

I also made the changes on the README to represent this changes, a few dialog corrections and included myself on the thanks credits :smile:

Changes:
```
src:
 - Added command arguments for source input and skeleton output, do python main.py --help to see the commands
 - Removed the src/ and bin/ directories since you can now specify paths, no need to move files here
```

Any feedback I'm here to respond