### PR TITLE
Fixed check when 'Pi_InitModule' doesn't start with 'PyObject'

### DIFF
--- a/skeleton_maker/source_file.py
+++ b/skeleton_maker/source_file.py
@@ -84,8 +84,8 @@ class SourceFile:
 				)
 
 		# If object isn't returned, module can't have constant -> End of reading()
-		if not object_name:
-			return
+		# if not object_name:
+			# return
 
 		# Find all constants :
 		# For each function used to register constants:


### PR DESCRIPTION
[PythonDebugModule.zip](https://github.com/nicolasCDT/Metin2_Module_skeleton_maker/files/10297518/PythonDebugModule.zip)

If you try to get **dbg.py** without the fix, it won't create.
